### PR TITLE
Fix: Increase dependabot interval length from one day to one week

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,7 +12,7 @@ updates:
     open-pull-requests-limit: 10
     package-ecosystem: "composer"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     versioning-strategy: "increase"
 
   - commit-message:
@@ -24,4 +24,4 @@ updates:
     open-pull-requests-limit: 10
     package-ecosystem: "github-actions"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
This pull request

* [x] increases the dependabot interval length from one day to one week