### PR TITLE
Fix: Disallow injection of Validator into SchemaValidator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a full diff see [`1.0.0...main`][1.0.0...main].
 - Dropped support for PHP 7.3 ([#137]), by [@localheinz]
 - Renamed `Json::encoded()` to `Json::toString()` ([#155]), by [@localheinz]
 - Inlined `Decoder` into `SchemaValidator` ([#157]), by [@localheinz]
+- Disallowed injection of `Validator` into `SchemaValidator` ([#158]), by [@localheinz]
 
 ## [`1.0.0`][1.0.0]
 
@@ -39,5 +40,6 @@ For a full diff see [`dcd4cfb...1.0.0`][dcd4cfb...1.0.0].
 [#137]: https://github.com/ergebnis/json-schema-validator/pull/137
 [#155]: https://github.com/ergebnis/json-schema-validator/pull/155
 [#157]: https://github.com/ergebnis/json-schema-validator/pull/157
+[#158]: https://github.com/ergebnis/json-schema-validator/pull/158
 
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -36,13 +36,12 @@ This package delegates the validation to `justinrainbow/json-schema` and provide
 <?php
 
 use Ergebnis\Json\SchemaValidator;
-use JsonSchema\Validator;
 
 $json = SchemaValidator\Json::fromFile('composer.json');
 
 $schema = SchemaValidator\Schema::fromJson(SchemaValidator\Json::fromString(file_get_contents('https://getcomposer.org/schema.json')));
 
-$schemaValidator = new SchemaValidator\SchemaValidator(new Validator());
+$schemaValidator = new SchemaValidator\SchemaValidator();
 
 $result = $schemaValidator->validate(
     $json,

--- a/infection.json
+++ b/infection.json
@@ -3,8 +3,8 @@
   "logs": {
     "text": ".build/infection/infection-log.txt"
   },
-  "minCoveredMsi": 76,
-  "minMsi": 75,
+  "minCoveredMsi": 74,
+  "minMsi": 72,
   "phpUnit": {
     "configDir": "test\/Unit"
   },

--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -17,20 +17,15 @@ use JsonSchema\Validator;
 
 final class SchemaValidator
 {
-    private Validator $validator;
-
-    public function __construct(Validator $validator)
-    {
-        $this->validator = $validator;
-    }
-
     public function validate(
         Json $json,
         Schema $schema
     ): Result {
-        $this->validator->reset();
+        $validator = new Validator();
 
-        $this->validator->check(
+        $validator->reset();
+
+        $validator->check(
             \json_decode(
                 $json->toString(),
                 false,
@@ -39,7 +34,7 @@ final class SchemaValidator
         );
 
         /** @var array<int, array> $originalErrors */
-        $originalErrors = $this->validator->getErrors();
+        $originalErrors = $validator->getErrors();
 
         $errors = \array_map(static function (array $error): string {
             $property = '';

--- a/test/Unit/SchemaValidatorTest.php
+++ b/test/Unit/SchemaValidatorTest.php
@@ -17,7 +17,6 @@ use Ergebnis\Json\SchemaValidator\Json;
 use Ergebnis\Json\SchemaValidator\Schema;
 use Ergebnis\Json\SchemaValidator\SchemaValidator;
 use Ergebnis\Json\SchemaValidator\Test;
-use JsonSchema\Validator;
 use PHPUnit\Framework;
 
 /**
@@ -73,7 +72,7 @@ JSON
 JSON
         ));
 
-        $validator = new SchemaValidator(new Validator());
+        $validator = new SchemaValidator();
 
         $result = $validator->validate(
             $json,
@@ -132,7 +131,7 @@ JSON
 JSON
         ));
 
-        $validator = new SchemaValidator(new Validator());
+        $validator = new SchemaValidator();
 
         $result = $validator->validate(
             $json,
@@ -192,7 +191,7 @@ JSON
 JSON
         ));
 
-        $validator = new SchemaValidator(new Validator());
+        $validator = new SchemaValidator();
 
         $validator->validate(
             $invalidJson,


### PR DESCRIPTION
This pull request

- [x] disallows injection of a `Validator` into the `SchemaValidator`