### PR TITLE
Enhancement: Use `JSON_THROW_ON_ERROR`

### DIFF
--- a/infection.json
+++ b/infection.json
@@ -3,8 +3,8 @@
   "logs": {
     "text": ".build/infection/infection-log.txt"
   },
-  "minCoveredMsi": 74,
-  "minMsi": 72,
+  "minCoveredMsi": 70,
+  "minMsi": 68,
   "phpUnit": {
     "configDir": "test\/Unit"
   },

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="v4.15.0@a1b5e489e6fcebe40cb804793d964e99fc347820">
   <file src="src/Json.php">
-    <MixedAssignment occurrences="2">
-      <code>$decoded</code>
-      <code>$decoded</code>
-    </MixedAssignment>
+    <UnusedFunctionCall occurrences="2">
+      <code>\json_decode</code>
+      <code>\json_decode</code>
+    </UnusedFunctionCall>
   </file>
   <file src="src/Result.php">
     <MixedPropertyTypeCoercion occurrences="1">

--- a/src/Json.php
+++ b/src/Json.php
@@ -30,12 +30,14 @@ final class Json
      */
     public static function fromString(string $value): self
     {
-        $decoded = \json_decode($value);
-
-        if (
-            null === $decoded
-            && \JSON_ERROR_NONE !== \json_last_error()
-        ) {
+        try {
+            \json_decode(
+                $value,
+                true,
+                512,
+                \JSON_THROW_ON_ERROR,
+            );
+        } catch (\JsonException $exception) {
             throw Exception\InvalidJson::string();
         }
 
@@ -59,12 +61,14 @@ final class Json
             throw Exception\CanNotBeRead::file($file);
         }
 
-        $decoded = \json_decode($value);
-
-        if (
-            null === $decoded
-            && \JSON_ERROR_NONE !== \json_last_error()
-        ) {
+        try {
+            \json_decode(
+                $value,
+                true,
+                512,
+                \JSON_THROW_ON_ERROR,
+            );
+        } catch (\JsonException $exception) {
             throw Exception\InvalidJson::file($file);
         }
 


### PR DESCRIPTION
This pull request

- [x] makes use of the `JSON_THROW_ON_ERROR` flag when decoding JSON `string`s