### PR TITLE
Fix: Use `validate()` instead of `check()`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -11,6 +11,11 @@
       <code>$errors</code>
     </MixedPropertyTypeCoercion>
   </file>
+  <file src="src/SchemaValidator.php">
+    <MixedAssignment occurrences="1">
+      <code>$jsonDecoded</code>
+    </MixedAssignment>
+  </file>
   <file src="test/DataProvider/JsonProvider.php">
     <MoreSpecificReturnType occurrences="2">
       <code>\Generator&lt;string, array{0: string}&gt;</code>

--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -25,11 +25,13 @@ final class SchemaValidator
 
         $validator->reset();
 
-        $validator->check(
-            \json_decode(
-                $json->toString(),
-                false,
-            ),
+        $jsonDecoded = \json_decode(
+            $json->toString(),
+            false,
+        );
+
+        $validator->validate(
+            $jsonDecoded,
             $schema->decoded(),
         );
 


### PR DESCRIPTION
This pull request

- [x] uses `validate()` instead of `check()`