### PR TITLE
Fix: Rename `Error` to `ValidationError`

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -19,18 +19,18 @@ namespace Ergebnis\Json\SchemaValidator;
 final class Result
 {
     /**
-     * @psalm-var list<Error>
+     * @psalm-var list<ValidationError>
      *
-     * @var array<int, Error>
+     * @var array<int, ValidationError>
      */
     private array $errors;
 
-    private function __construct(Error ...$errors)
+    private function __construct(ValidationError ...$errors)
     {
         $this->errors = $errors;
     }
 
-    public static function create(Error ...$errors): self
+    public static function create(ValidationError ...$errors): self
     {
         return new self(...$errors);
     }
@@ -41,9 +41,9 @@ final class Result
     }
 
     /**
-     * @psalm-return list<Error>
+     * @psalm-return list<ValidationError>
      *
-     * @return array<int, Error>
+     * @return array<int, ValidationError>
      */
     public function errors(): array
     {

--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -79,13 +79,13 @@ final class SchemaValidator
         /** @var array<int, array> $originalErrors */
         $originalErrors = $validator->getErrors();
 
-        $errors = \array_map(static function (array $error): Error {
-            return Error::create(
+        $validationErrors = \array_map(static function (array $error): ValidationError {
+            return ValidationError::create(
                 JsonPointer::fromString($error['pointer']),
                 Message::fromString($error['message']),
             );
         }, $originalErrors);
 
-        return Result::create(...$errors);
+        return Result::create(...$validationErrors);
     }
 }

--- a/src/ValidationError.php
+++ b/src/ValidationError.php
@@ -16,7 +16,7 @@ namespace Ergebnis\Json\SchemaValidator;
 /**
  * @psalm-immutable
  */
-final class Error
+final class ValidationError
 {
     private JsonPointer $jsonPointer;
     private Message $message;

--- a/test/Unit/ResultTest.php
+++ b/test/Unit/ResultTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\SchemaValidator\Test\Unit;
 
-use Ergebnis\Json\SchemaValidator\Error;
 use Ergebnis\Json\SchemaValidator\JsonPointer;
 use Ergebnis\Json\SchemaValidator\Message;
 use Ergebnis\Json\SchemaValidator\Result;
 use Ergebnis\Json\SchemaValidator\Test;
+use Ergebnis\Json\SchemaValidator\ValidationError;
 use PHPUnit\Framework;
 
 /**
@@ -25,9 +25,9 @@ use PHPUnit\Framework;
  *
  * @covers \Ergebnis\Json\SchemaValidator\Result
  *
- * @uses \Ergebnis\Json\SchemaValidator\Error
  * @uses \Ergebnis\Json\SchemaValidator\JsonPointer
  * @uses \Ergebnis\Json\SchemaValidator\Message
+ * @uses \Ergebnis\Json\SchemaValidator\ValidationError
  */
 final class ResultTest extends Framework\TestCase
 {
@@ -46,15 +46,15 @@ final class ResultTest extends Framework\TestCase
         $faker = self::faker();
 
         $errors = [
-            Error::create(
+            ValidationError::create(
                 JsonPointer::fromString('/foo'),
                 Message::fromString($faker->sentence()),
             ),
-            Error::create(
+            ValidationError::create(
                 JsonPointer::fromString('/bar'),
                 Message::fromString($faker->sentence()),
             ),
-            Error::create(
+            ValidationError::create(
                 JsonPointer::fromString('/baz'),
                 Message::fromString($faker->sentence()),
             ),

--- a/test/Unit/SchemaValidatorTest.php
+++ b/test/Unit/SchemaValidatorTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\SchemaValidator\Test\Unit;
 
-use Ergebnis\Json\SchemaValidator\Error;
 use Ergebnis\Json\SchemaValidator\Exception;
 use Ergebnis\Json\SchemaValidator\Json;
 use Ergebnis\Json\SchemaValidator\JsonPointer;
 use Ergebnis\Json\SchemaValidator\Message;
 use Ergebnis\Json\SchemaValidator\SchemaValidator;
 use Ergebnis\Json\SchemaValidator\Test;
+use Ergebnis\Json\SchemaValidator\ValidationError;
 use PHPUnit\Framework;
 
 /**
@@ -27,13 +27,13 @@ use PHPUnit\Framework;
  *
  * @covers \Ergebnis\Json\SchemaValidator\SchemaValidator
  *
- * @uses \Ergebnis\Json\SchemaValidator\Error
  * @uses \Ergebnis\Json\SchemaValidator\Exception\CanNotResolve
  * @uses \Ergebnis\Json\SchemaValidator\Exception\ResolvedToRootSchema
  * @uses \Ergebnis\Json\SchemaValidator\Json
  * @uses \Ergebnis\Json\SchemaValidator\JsonPointer
  * @uses \Ergebnis\Json\SchemaValidator\Message
  * @uses \Ergebnis\Json\SchemaValidator\Result
+ * @uses \Ergebnis\Json\SchemaValidator\ValidationError
  */
 final class SchemaValidatorTest extends Framework\TestCase
 {
@@ -140,15 +140,15 @@ final class SchemaValidatorTest extends Framework\TestCase
         self::assertFalse($result->isValid());
 
         $expected = [
-            Error::create(
+            ValidationError::create(
                 JsonPointer::fromString('/foo/bar'),
                 Message::fromString('Integer value found, but a boolean is required'),
             ),
-            Error::create(
+            ValidationError::create(
                 JsonPointer::fromString('/foo/baz'),
                 Message::fromString('String value found, but an array is required'),
             ),
-            Error::create(
+            ValidationError::create(
                 JsonPointer::empty(),
                 Message::fromString('The property qux is not defined and the definition does not allow additional properties'),
             ),
@@ -349,11 +349,11 @@ final class SchemaValidatorTest extends Framework\TestCase
         self::assertFalse($result->isValid());
 
         $expected = [
-            Error::create(
+            ValidationError::create(
                 JsonPointer::fromString('/bar'),
                 Message::fromString('String value found, but a boolean is required'),
             ),
-            Error::create(
+            ValidationError::create(
                 JsonPointer::fromString('/baz'),
                 Message::fromString('Boolean value found, but an array is required'),
             ),

--- a/test/Unit/ValidationErrorTest.php
+++ b/test/Unit/ValidationErrorTest.php
@@ -13,35 +13,35 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\SchemaValidator\Test\Unit;
 
-use Ergebnis\Json\SchemaValidator\Error;
 use Ergebnis\Json\SchemaValidator\JsonPointer;
 use Ergebnis\Json\SchemaValidator\Message;
 use Ergebnis\Json\SchemaValidator\Test;
+use Ergebnis\Json\SchemaValidator\ValidationError;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Ergebnis\Json\SchemaValidator\Error
+ * @covers \Ergebnis\Json\SchemaValidator\ValidationError
  *
  * @uses \Ergebnis\Json\SchemaValidator\JsonPointer
  * @uses \Ergebnis\Json\SchemaValidator\Message
  */
-final class ErrorTest extends Framework\TestCase
+final class ValidationErrorTest extends Framework\TestCase
 {
     use Test\Util\Helper;
 
-    public function testCreateReturnsError(): void
+    public function testCreateReturnsValidationError(): void
     {
         $jsonPointer = JsonPointer::fromString('#/foo/bar');
         $message = Message::fromString(self::faker()->sentence());
 
-        $error = Error::create(
+        $validationError = ValidationError::create(
             $jsonPointer,
             $message,
         );
 
-        self::assertSame($jsonPointer, $error->jsonPointer());
-        self::assertSame($message, $error->message());
+        self::assertSame($jsonPointer, $validationError->jsonPointer());
+        self::assertSame($message, $validationError->message());
     }
 }


### PR DESCRIPTION
This pull request

- [x] renames `Error` to `ValidationError`