### PR TITLE
Fix: Rename `Result` to `ValidationResult`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For a full diff see [`1.0.0...main`][1.0.0...main].
 - Removed `Schema` ([#161]), by [@localheinz]
 - Composed `Error` into `Result` ([#166]), by [@localheinz]
 - Required `JsonPointer` to allow specifying sub-schemas ([#167]), by [@localheinz]
+- Renamed `Result` to `ValidationResult` ([#172]), by [@localheinz]
 
 ## [`1.0.0`][1.0.0]
 
@@ -56,5 +57,6 @@ For a full diff see [`dcd4cfb...1.0.0`][dcd4cfb...1.0.0].
 [#165]: https://github.com/ergebnis/json-schema-validator/pull/165
 [#166]: https://github.com/ergebnis/json-schema-validator/pull/166
 [#167]: https://github.com/ergebnis/json-schema-validator/pull/167
+[#172]: https://github.com/ergebnis/json-schema-validator/pull/172
 
 [@localheinz]: https://github.com/localheinz

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6,11 +6,6 @@
       <code>\json_decode</code>
     </UnusedFunctionCall>
   </file>
-  <file src="src/Result.php">
-    <MixedPropertyTypeCoercion occurrences="1">
-      <code>$errors</code>
-    </MixedPropertyTypeCoercion>
-  </file>
   <file src="src/SchemaValidator.php">
     <MixedArgument occurrences="3">
       <code>$error['message']</code>
@@ -21,6 +16,11 @@
       <code>$jsonDecoded</code>
       <code>$schemaDecoded</code>
     </MixedAssignment>
+  </file>
+  <file src="src/ValidationResult.php">
+    <MixedPropertyTypeCoercion occurrences="1">
+      <code>$errors</code>
+    </MixedPropertyTypeCoercion>
   </file>
   <file src="test/DataProvider/JsonProvider.php">
     <MoreSpecificReturnType occurrences="2">

--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -31,7 +31,7 @@ final class SchemaValidator
         Json $json,
         Json $schema,
         JsonPointer $jsonPointer
-    ): Result {
+    ): ValidationResult {
         $schemaDecoded = \json_decode(
             $schema->toString(),
             false,
@@ -86,6 +86,6 @@ final class SchemaValidator
             );
         }, $originalErrors);
 
-        return Result::create(...$validationErrors);
+        return ValidationResult::create(...$validationErrors);
     }
 }

--- a/src/ValidationResult.php
+++ b/src/ValidationResult.php
@@ -16,7 +16,7 @@ namespace Ergebnis\Json\SchemaValidator;
 /**
  * @psalm-immutable
  */
-final class Result
+final class ValidationResult
 {
     /**
      * @psalm-var list<ValidationError>

--- a/test/Unit/SchemaValidatorTest.php
+++ b/test/Unit/SchemaValidatorTest.php
@@ -32,8 +32,8 @@ use PHPUnit\Framework;
  * @uses \Ergebnis\Json\SchemaValidator\Json
  * @uses \Ergebnis\Json\SchemaValidator\JsonPointer
  * @uses \Ergebnis\Json\SchemaValidator\Message
- * @uses \Ergebnis\Json\SchemaValidator\Result
  * @uses \Ergebnis\Json\SchemaValidator\ValidationError
+ * @uses \Ergebnis\Json\SchemaValidator\ValidationResult
  */
 final class SchemaValidatorTest extends Framework\TestCase
 {

--- a/test/Unit/ValidationResultTest.php
+++ b/test/Unit/ValidationResultTest.php
@@ -15,33 +15,33 @@ namespace Ergebnis\Json\SchemaValidator\Test\Unit;
 
 use Ergebnis\Json\SchemaValidator\JsonPointer;
 use Ergebnis\Json\SchemaValidator\Message;
-use Ergebnis\Json\SchemaValidator\Result;
 use Ergebnis\Json\SchemaValidator\Test;
 use Ergebnis\Json\SchemaValidator\ValidationError;
+use Ergebnis\Json\SchemaValidator\ValidationResult;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Ergebnis\Json\SchemaValidator\Result
+ * @covers \Ergebnis\Json\SchemaValidator\ValidationResult
  *
  * @uses \Ergebnis\Json\SchemaValidator\JsonPointer
  * @uses \Ergebnis\Json\SchemaValidator\Message
  * @uses \Ergebnis\Json\SchemaValidator\ValidationError
  */
-final class ResultTest extends Framework\TestCase
+final class ValidationResultTest extends Framework\TestCase
 {
     use Test\Util\Helper;
 
-    public function testCreateReturnsResultWithoutErrors(): void
+    public function testCreateReturnsValidationResultWithoutErrors(): void
     {
-        $result = Result::create();
+        $validationResult = ValidationResult::create();
 
-        self::assertTrue($result->isValid());
-        self::assertSame([], $result->errors());
+        self::assertTrue($validationResult->isValid());
+        self::assertSame([], $validationResult->errors());
     }
 
-    public function testCreateReturnsResultWithErrors(): void
+    public function testCreateReturnsValidationResultWithErrors(): void
     {
         $faker = self::faker();
 
@@ -60,9 +60,9 @@ final class ResultTest extends Framework\TestCase
             ),
         ];
 
-        $result = Result::create(...$errors);
+        $validationResult = ValidationResult::create(...$errors);
 
-        self::assertFalse($result->isValid());
-        self::assertSame($errors, $result->errors());
+        self::assertFalse($validationResult->isValid());
+        self::assertSame($errors, $validationResult->errors());
     }
 }


### PR DESCRIPTION
This pull request

- [x] renames `Result` to `ValidationResult`