### PR TITLE
Fix: Declare strict types

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ This package delegates the validation to `justinrainbow/json-schema` and provide
 ```php
 <?php
 
+declare(strict_types=1);
+
 use Ergebnis\Json\SchemaValidator;
 
 $json = SchemaValidator\Json::fromFile('composer.json');


### PR DESCRIPTION
This pull request

- [x] declares strict types in examples in  `README.md`