### PR TITLE
Fix: Throw `CanNotResolve` instead of ResolvedToRootSchema when JSON pointer is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`2.0.0...main`][2.0.0...main].
 ### Changed
 
 - Required [`ergebnis/json-pointer`](https://github.com/ergebnis/json-pointer) ([#195]), by [@localheinz]
+- Started throwing an `Exception\CanNotResolve` exception instead of an `Exception\ResolvedToRootSchema` when the `JsonPointer` is not a valid URI fragment identifier representation of a JSON pointer ([#202]), by [@localheinz]
 
 ## [`2.0.0`][2.0.0]
 
@@ -71,5 +72,6 @@ For a full diff see [`dcd4cfb...1.0.0`][dcd4cfb...1.0.0].
 [#169]: https://github.com/ergebnis/json-schema-validator/pull/169
 [#172]: https://github.com/ergebnis/json-schema-validator/pull/172
 [#195]: https://github.com/ergebnis/json-schema-validator/pull/195
+[#202]: https://github.com/ergebnis/json-schema-validator/pull/202
 
 [@localheinz]: https://github.com/localheinz

--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Ergebnis\Json\SchemaValidator;
 
 use Ergebnis\Json\SchemaValidator\Exception\CanNotResolve;
-use Ergebnis\Json\SchemaValidator\Exception\ResolvedToRootSchema;
 use JsonSchema\Constraints;
 use JsonSchema\Exception;
 use JsonSchema\SchemaStorage;
@@ -25,7 +24,6 @@ final class SchemaValidator
 {
     /**
      * @throws CanNotResolve
-     * @throws ResolvedToRootSchema
      */
     public function validate(
         Json $json,
@@ -50,7 +48,7 @@ final class SchemaValidator
             }
 
             if ($schemaDecoded === $subSchemaDecoded) {
-                throw ResolvedToRootSchema::jsonPointer($jsonPointer);
+                throw CanNotResolve::jsonPointer($jsonPointer);
             }
 
             $schemaDecoded = $subSchemaDecoded;

--- a/test/Unit/Exception/CanNotResolveTest.php
+++ b/test/Unit/Exception/CanNotResolveTest.php
@@ -28,7 +28,7 @@ final class CanNotResolveTest extends Framework\TestCase
 {
     public function testJsonPointerReturnsException(): void
     {
-        $jsonPointer = JsonPointer::fromString('/foo/bar');
+        $jsonPointer = JsonPointer::fromString('#/foo/bar');
 
         $exception = Exception\CanNotResolve::jsonPointer($jsonPointer);
 

--- a/test/Unit/Exception/ResolvedToRootSchemaTest.php
+++ b/test/Unit/Exception/ResolvedToRootSchemaTest.php
@@ -28,7 +28,7 @@ final class ResolvedToRootSchemaTest extends Framework\TestCase
 {
     public function testJsonPointerReturnsException(): void
     {
-        $jsonPointer = JsonPointer::fromString('/foo/bar');
+        $jsonPointer = JsonPointer::fromString('#/foo/bar');
 
         $exception = Exception\ResolvedToRootSchema::jsonPointer($jsonPointer);
 

--- a/test/Unit/SchemaValidatorTest.php
+++ b/test/Unit/SchemaValidatorTest.php
@@ -253,7 +253,7 @@ final class SchemaValidatorTest extends Framework\TestCase
         );
     }
 
-    public function testValidateThrowsResolvedToRootSchemaWhenJsonPointerIsNotEmptyAndSubSchemaWasResolvedToRootSchema(): void
+    public function testValidateThrowsCanNotResolveWhenJsonPointerIsNotEmptyButCouldNotBeParsedAsUriFragmentIdentifierString(): void
     {
         $faker = self::faker();
 
@@ -292,7 +292,7 @@ final class SchemaValidatorTest extends Framework\TestCase
 
         $schemaValidator = new SchemaValidator();
 
-        $this->expectException(Exception\ResolvedToRootSchema::class);
+        $this->expectException(Exception\CanNotResolve::class);
 
         $schemaValidator->validate(
             $data,


### PR DESCRIPTION
This pull request

- [x] throws a `CanNotResolve` exception instead of a `ResolvedToRootSchema` exception when a JSON pointer is not a valid URI fragment identifier 
